### PR TITLE
Handle confluent registry schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ $ bundle
 * **writers_schema_json** (string) (optional): avro schema definition hash for writers definition.
 * **readers_schema_file** (string) (optional): avro schema file path for readers definition.
 * **readers_schema_json** (string) (optional): avro schema definition hash for readers definition.
+* **use_confluent_schema** (bool) (optional): Assume to use confluent schema. Confluent avro schema uses the first 5-bytes for magic byte (1 byte) and schema_id (4 bytes). This parameter specifies to skip reading the first 5-bytes or not.
+  * Default value: `true`.
 
 ### Configuration Example
 
@@ -49,6 +51,8 @@ $ bundle
   # schema_url http(s)://[server fqdn]:[port]/subjects/[a great user's subject]/[the latest schema version]
   # schema_key schema
   # schema_registery_with_subject_url http(s)://[server fqdn]:[port]/subjects/[a great user's subject]/
+  # When using with confluent registry, this parameter must be true.
+  # use_confluent_schema true
 </parse>
 ```
 
@@ -74,6 +78,16 @@ For example, when specifying the following configuration:
 ```
 
 Then the parser plugin calls `GET http://localhost:8081/subjects/persons-avro-value/versions/` to retrive the registered schema versions and then calls `GET GET http://localhost:8081/subjects/persons-avro-value/versions/<the latest schema version>`.
+
+If you use this plugin with confluent registry, please specify `use_confluent_schema` as `true`.
+
+This is because, confluent avro schema uses the following structure:
+
+MAGIC_BYTE | schema_id | record
+----------:|:---------:|:---------------
+ 1byte     |  4bytes   | record contents
+
+When specifying `use_confluent_schema` as `true`, this plugin will skip to read the first 5-bytes.
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ $ bundle
 * **schema_file** (string) (optional): avro schema file path.
 * **schema_json** (string) (optional): avro schema definition hash.
 * **schema_url** (string) (optional): avro schema remote URL.
-* **schema_registery_with_subject_url** (string) (optional): avro schema registry URL.
 * **schema_url_key** (string) (optional): avro schema registry or something's response schema key.
 * **writers_schema_file** (string) (optional): avro schema file path for writers definition.
 * **writers_schema_json** (string) (optional): avro schema definition hash for writers definition.
@@ -40,6 +39,15 @@ $ bundle
 * **readers_schema_json** (string) (optional): avro schema definition hash for readers definition.
 * **use_confluent_schema** (bool) (optional): Assume to use confluent schema. Confluent avro schema uses the first 5-bytes for magic byte (1 byte) and schema_id (4 bytes). This parameter specifies to skip reading the first 5-bytes or not.
   * Default value: `true`.
+
+### \<confluent_registry\> section (optional) (single)
+
+* **url** (string) (required): confluent schema registry URL.
+* **subject** (string) (required): Specify schema subject.
+* **schema_key** (string) (optional): Specify schema key on confluent registry REST API response.
+  * Default value: `schema`.
+* **schema_version** (string) (optional): Specify schema version for the specified subject.
+  * Default value: `latest`.
 
 ### Configuration Example
 
@@ -50,9 +58,14 @@ $ bundle
   # schema_json { "namespace": "org.fluentd.parser.avro", "type": "record", "name": "User", "fields" : [{"name": "username", "type": "string"}, {"name": "age", "type": "int"}, {"name": "verified", "type": ["boolean", "null"], "default": false}]}
   # schema_url http(s)://[server fqdn]:[port]/subjects/[a great user's subject]/[the latest schema version]
   # schema_key schema
-  # schema_registery_with_subject_url http(s)://[server fqdn]:[port]/subjects/[a great user's subject]/
-  # When using with confluent registry, this parameter must be true.
+  # When using with confluent registry without <confluent_registry>, this parameter must be true.
   # use_confluent_schema true
+  #<confluent_registry>
+  #  url http://localhost:8081/
+  #  subject your-awesome-subject
+  #  # schema_key schema
+  #  # schema_version 1
+  #</confluent_registry>
 </parse>
 ```
 
@@ -62,24 +75,36 @@ Confluent AVRO schema registry should respond with REST API.
 
 This plugin uses the following API:
 
-* [`GET /subjects/(string: subject)/versions`](https://docs.confluent.io/current/schema-registry/develop/api.html#get--subjects-(string-%20subject)-versions)
 * [`GET /subjects/(string: subject)/versions/(versionId: version)`](https://docs.confluent.io/current/schema-registry/develop/api.html#get--subjects-(string-%20subject)-versions)
 
-Users can specify a URL for retrieving the latest schemna information:
+Users can specify a URL for retrieving the latest schemna information with `<confluent_registry>`:
 
-e.g.) `http(s)://[server fqdn]:[port]/subjects/[a great user's subject]/`
+e.g.)
+```
+  <confluent_registry>
+    url http://[confluent registry server ip]:[port]/
+    subject your-awesome-subject
+    # schema_key schema
+    # schema_version 1
+  </confluent_registry>
+```
 
 For example, when specifying the following configuration:
 
 ```
 <parse>
   @type avro
-  schema_registery_with_subject_url http://localhost:8081/subjects/persons-avro-value/
+  <confluent_registry>
+    url http://localhost:8081/
+    subject persons-avro-value
+    # schema_key schema
+    # schema_version 1
+  </confluent_registry>
 ```
 
-Then the parser plugin calls `GET http://localhost:8081/subjects/persons-avro-value/versions/` to retrive the registered schema versions and then calls `GET GET http://localhost:8081/subjects/persons-avro-value/versions/<the latest schema version>`.
+Then the parser plugin calls `GET http://localhost:8081/subjects/persons-avro-value/versions/latest` to retrive the registered schema versions. And when parsing failure occurred, this plugin will call `GET http://localhost:8081/schemas/ids/<schema id which is obtained from the second record on avro schema>`.
 
-If you use this plugin with confluent registry, please specify `use_confluent_schema` as `true`.
+If you use this plugin to parse confluent schema, please specify `use_confluent_schema` as `true`.
 
 This is because, confluent avro schema uses the following structure:
 
@@ -87,7 +112,7 @@ MAGIC_BYTE | schema_id | record
 ----------:|:---------:|:---------------
  1byte     |  4bytes   | record contents
 
-When specifying `use_confluent_schema` as `true`, this plugin will skip to read the first 5-bytes.
+When specifying `<confluent_registry>` section on configuration, this plugin will skip to read the first 5-bytes automatically and parse `schema_id` from there.
 
 ## Copyright
 

--- a/lib/fluent/plugin/confluent_avro_schema_registry.rb
+++ b/lib/fluent/plugin/confluent_avro_schema_registry.rb
@@ -1,0 +1,49 @@
+#
+# Copyright 2020- Hiroshi Hatake
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "net/http"
+require "uri"
+
+module Fluent
+  module Plugin
+    class ConfluentAvroSchemaRegistry
+      def initialize(registry_url)
+        @registry_url = registry_url
+      end
+
+      def subject_version(subject, schema_key, version = "latest")
+        registry_uri = URI.parse(@registry_url)
+        registry_uri_with_versions = URI.join(registry_uri, "subjects/#{subject}/versions/#{version}")
+        response = Net::HTTP.get_response(registry_uri_with_versions)
+        if schema_key.nil?
+          response.body
+        else
+          Yajl.load(response.body)[schema_key]
+        end
+      end
+
+      def schema_with_id(schema_id, schema_key)
+        registry_uri = URI.parse(@registry_url)
+        registry_uri_with_ids = URI.join(registry_uri, "schemas/ids/#{schema_id}")
+        response = Net::HTTP.get_response(registry_uri_with_ids)
+        if schema_key.nil?
+          response.body
+        else
+          Yajl.load(response.body)[schema_key]
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin/confluent_avro_schema_registry.rb
+++ b/lib/fluent/plugin/confluent_avro_schema_registry.rb
@@ -25,7 +25,7 @@ module Fluent
 
       def subject_version(subject, schema_key, version = "latest")
         registry_uri = URI.parse(@registry_url)
-        registry_uri_with_versions = URI.join(registry_uri, "subjects/#{subject}/versions/#{version}")
+        registry_uri_with_versions = URI.join(registry_uri, "/subjects/#{subject}/versions/#{version}")
         response = Net::HTTP.get_response(registry_uri_with_versions)
         if schema_key.nil?
           response.body
@@ -36,7 +36,7 @@ module Fluent
 
       def schema_with_id(schema_id, schema_key)
         registry_uri = URI.parse(@registry_url)
-        registry_uri_with_ids = URI.join(registry_uri, "schemas/ids/#{schema_id}")
+        registry_uri_with_ids = URI.join(registry_uri, "/schemas/ids/#{schema_id}")
         response = Net::HTTP.get_response(registry_uri_with_ids)
         if schema_key.nil?
           response.body

--- a/lib/fluent/plugin/parser_avro.rb
+++ b/lib/fluent/plugin/parser_avro.rb
@@ -30,7 +30,6 @@ module Fluent
       config_param :schema_file, :string, :default => nil
       config_param :schema_json, :string, :default => nil
       config_param :schema_url, :string, :default => nil
-      config_param :schema_registery_with_subject_url, :string, :default => nil
       config_param :schema_url_key, :string, :default => nil
       config_param :writers_schema_file, :string, :default => nil
       config_param :writers_schema_json, :string, :default => nil
@@ -78,17 +77,12 @@ module Fluent
           @schema = Avro::Schema.parse(@raw_schema)
           @reader = Avro::IO::DatumReader.new(@schema)
         else
-          unless [@schema_json, @schema_file, @schema_url, @schema_registery_with_subject_url].compact.size == 1
+          unless [@schema_json, @schema_file, @schema_url].compact.size == 1
             raise Fluent::ConfigError, "schema_json, schema_file, or schema_url is required, but they cannot specify at the same time!"
-          end
-          if @schema_registery_with_subject_url && !@schema_registery_with_subject_url.end_with?("/")
-            raise Fluent::ConfigError, "schema_registery_with_subject_url must contain the trailing slash('/')."
           end
 
           @raw_schema = if @schema_file
                           File.read(@schema_file)
-                        elsif @schema_registery_with_subject_url
-                          fetch_latest_schema(@schema_registery_with_subject_url, @schema_url_key)
                         elsif @schema_url
                           fetch_schema(@schema_url, @schema_url_key)
                         elsif @schema_json
@@ -125,15 +119,13 @@ module Fluent
           time, record = convert_values(parse_time(decoded_data), decoded_data)
           yield time, record
         rescue EOFError, RuntimeError => e
-          raise e unless [@schema_url, @schema_registery_with_subject_url, @avro_registry].compact.size == 1
+          raise e unless [@schema_url, @avro_registry].compact.size == 1
           begin
             new_raw_schema = if @schema_url
                                fetch_schema(@schema_url, @schema_url_key)
                              elsif @avro_registry
                                @confluent_registry.schema_with_id(schema_id,
                                                                   @avro_registry.schema_key)
-                             elsif @schema_registery_with_subject_url
-                               fetch_latest_schema(@schema_registery_with_subject_url, @schema_url_key)
                              end
             new_schema = Avro::Schema.parse(new_raw_schema)
             is_changed = (new_raw_schema != @raw_schema)
@@ -165,24 +157,6 @@ module Fluent
           else
             raise e
           end
-        end
-      end
-
-      def fetch_schema_versions(base_uri_with_versions)
-        versions_response = Net::HTTP.get_response(base_uri_with_versions)
-        Yajl.load(versions_response.body)
-      end
-
-      def fetch_latest_schema(base_url, schema_key)
-        base_uri = URI.parse(base_url)
-        base_uri_with_versions = URI.join(base_uri, "versions/")
-        versions = fetch_schema_versions(base_uri_with_versions)
-        uri = URI.join(base_uri_with_versions, versions.last.to_s)
-        response = Net::HTTP.get_response(uri)
-        if schema_key.nil?
-          response.body
-        else
-          Yajl.load(response.body)[schema_key]
         end
       end
 

--- a/lib/fluent/plugin/parser_avro.rb
+++ b/lib/fluent/plugin/parser_avro.rb
@@ -143,6 +143,9 @@ module Fluent
             # Do nothing.
           end
           if is_changed
+            buffer = StringIO.new(data)
+            decoder = Avro::IO::BinaryDecoder.new(buffer)
+            @reader = Avro::IO::DatumReader.new(@schema)
             decoded_data = @reader.read(decoder)
             time, record = convert_values(parse_time(decoded_data), decoded_data)
             yield time, record

--- a/test/data/schema-persions-value-1.avsc
+++ b/test/data/schema-persions-value-1.avsc
@@ -1,0 +1,1 @@
+{"schema":"{\"type\":\"record\",\"name\":\"Person\",\"namespace\":\"com.ippontech.kafkatutorials\",\"fields\":[{\"name\":\"firstName\",\"type\":\"string\"},{\"name\":\"lastName\",\"type\":\"string\"},{\"name\":\"birthDate\",\"type\":\"long\"}]}"}

--- a/test/data/schema-persions-value-21.avsc
+++ b/test/data/schema-persions-value-21.avsc
@@ -1,0 +1,1 @@
+{"schema":"{\"type\":\"record\",\"name\":\"Person\",\"namespace\":\"com.ippontech.kafkatutorials\",\"fields\":[{\"name\":\"firstName\",\"type\":\"string\"},{\"name\":\"lastName\",\"type\":\"string\"},{\"name\":\"birthDate\",\"type\":\"long\"},{\"name\":\"verified\",\"type\":\"boolean\",\"default\":false}]}"}

--- a/test/data/schema-persions-value-41.avsc
+++ b/test/data/schema-persions-value-41.avsc
@@ -1,0 +1,1 @@
+{"schema":"{\"type\":\"record\",\"name\":\"Person\",\"namespace\":\"com.ippontech.kafkatutorials\",\"fields\":[{\"name\":\"firstName\",\"type\":\"string\"},{\"name\":\"lastName\",\"type\":\"string\"},{\"name\":\"birthDate\",\"type\":\"long\"},{\"name\":\"verified\",\"type\":\"boolean\"}]}"}

--- a/test/data/schema-persions-value-42.avsc
+++ b/test/data/schema-persions-value-42.avsc
@@ -1,0 +1,1 @@
+{"schema":"{\"type\":\"record\",\"name\":\"Person\",\"namespace\":\"com.ippontech.kafkatutorials\",\"fields\":[{\"name\":\"firstName\",\"type\":\"string\"},{\"name\":\"lastName\",\"type\":\"string\"},{\"name\":\"birthDate\",\"type\":\"long\"},{\"name\":\"verified\",\"type\":[\"boolean\",\"null\"],\"default\":false}]}"}

--- a/test/plugin/test_parser_avro.rb
+++ b/test/plugin/test_parser_avro.rb
@@ -76,74 +76,94 @@ class AvroParserTest < Test::Unit::TestCase
     }
   EOC
 
-  def test_parse
+  data("use_confluent_schema" => true,
+       "plain"                => false)
+  def test_parse(data)
+    config = data
     conf = {
-      'schema_json' => SCHEMA
+      'schema_json' => SCHEMA,
+      'use_confluent_schema' => config,
     }
     d = create_driver(conf)
     datum = {"username" => "foo", "age" => 42, "verified" => true}
-    encoded = encode_datum(datum, SCHEMA)
+    encoded = encode_datum(datum, SCHEMA, config)
     d.instance.parse(encoded) do |_time, record|
       assert_equal datum, record
     end
 
     datum = {"username" => "baz", "age" => 34}
-    encoded = encode_datum(datum, SCHEMA)
+    encoded = encode_datum(datum, SCHEMA, config)
     d.instance.parse(encoded) do |_time, record|
       assert_equal datum.merge("verified" => nil), record
     end
   end
 
-  def test_parse_with_avro_schema
+  data("use_confluent_schema" => true,
+       "plain"                => false)
+  def test_parse_with_avro_schema(data)
+    config = data
     conf = {
-      'schema_file' => File.join(__dir__, "..", "data", "user.avsc")
+      'schema_file' => File.join(__dir__, "..", "data", "user.avsc"),
+      'use_confluent_schema' => config,
     }
     d = create_driver(conf)
     datum = {"username" => "foo", "age" => 42, "verified" => true}
-    encoded = encode_datum(datum, SCHEMA)
+    encoded = encode_datum(datum, SCHEMA, config)
     d.instance.parse(encoded) do |_time, record|
       assert_equal datum, record
     end
 
     datum = {"username" => "baz", "age" => 34}
-    encoded = encode_datum(datum, SCHEMA)
+    encoded = encode_datum(datum, SCHEMA, config)
     d.instance.parse(encoded) do |_time, record|
       assert_equal datum.merge("verified" => nil), record
     end
   end
 
-  def test_parse_with_readers_and_writers_schema
+  data("use_confluent_schema" => true,
+       "plain"                => false)
+  def test_parse_with_readers_and_writers_schema(data)
+    config = data
     conf = {
       'writers_schema_json' => SCHEMA,
       'readers_schema_json' => READERS_SCHEMA,
+      'use_confluent_schema' => config,
     }
     d = create_driver(conf)
     datum = {"username" => "foo", "age" => 42, "verified" => true}
-    encoded = encode_datum(datum, SCHEMA)
+    encoded = encode_datum(datum, SCHEMA, config)
     d.instance.parse(encoded) do |_time, record|
       datum.delete("verified")
       assert_equal datum, record
     end
   end
 
-  def test_parse_with_readers_and_writers_schema_files
+  data("use_confluent_schema" => true,
+       "plain"                => false)
+  def test_parse_with_readers_and_writers_schema_files(data)
+    config = data
     conf = {
       'writers_schema_file' => File.join(__dir__, "..", "data", "writer_user.avsc"),
       'readers_schema_file' => File.join(__dir__, "..", "data", "reader_user.avsc"),
+      'use_confluent_schema' => config,
     }
     d = create_driver(conf)
     datum = {"username" => "foo", "age" => 42, "verified" => true}
-    encoded = encode_datum(datum, SCHEMA)
+    encoded = encode_datum(datum, SCHEMA, config)
     d.instance.parse(encoded) do |_time, record|
       datum.delete("verified")
       assert_equal datum, record
     end
   end
 
-  def test_parse_with_complex_schema
+  data("use_confluent_schema" => true,
+       "plain"                => false)
+  def test_parse_with_complex_schema(data)
+    config = data
     conf = {
       'schema_json' => COMPLEX_SCHEMA,
-      'time_key' => 'time'
+      'time_key' => 'time',
+      'use_confluent_schema' => config,
     }
     d = create_driver(conf)
     time_str = "2020-09-25 15:08:09.082113 +0900"
@@ -162,7 +182,7 @@ class AvroParserTest < Test::Unit::TestCase
       }
     }
 
-    encoded = encode_datum(datum, COMPLEX_SCHEMA)
+    encoded = encode_datum(datum, COMPLEX_SCHEMA, config)
     d.instance.parse(encoded) do |time, record|
       assert_equal Time.parse(time_str).to_r, time.to_r
       datum.delete("time")
@@ -320,46 +340,58 @@ class AvroParserTest < Test::Unit::TestCase
       assert_equal '3', @got[3][:version]
     end
 
-    def test_schema_url
+    data("use_confluent_schema" => true,
+         "plain"                => false)
+    def test_schema_url(data)
+      config = data
       conf = {
         'schema_url' => "http://localhost:8081/subjects/persons-avro-value/versions/1",
-        'schema_url_key' => 'schema'
+        'schema_url_key' => 'schema',
+        'use_confluent_schema' => config,
       }
       d = create_driver(conf)
       datum = {"firstName" => "Aleen","lastName" => "Terry","birthDate" => 159202477258}
-      encoded = encode_datum(datum, REMOTE_SCHEMA)
+      encoded = encode_datum(datum, REMOTE_SCHEMA, config)
       d.instance.parse(encoded) do |_time, record|
         assert_equal datum, record
       end
     end
 
-    def test_schema_url_with_version2
+    data("use_confluent_schema" => true,
+         "plain"                => false)
+    def test_schema_url_with_version2(data)
+      config = data
       conf = {
         'schema_url' => "http://localhost:8081/subjects/persons-avro-value/versions/2",
-        'schema_url_key' => 'schema'
+        'schema_url_key' => 'schema',
+        'use_confluent_schema' => config,
       }
       d = create_driver(conf)
       datum = {"firstName" => "Aleen","lastName" => "Terry","birthDate" => 159202477258}
-      encoded = encode_datum(datum, REMOTE_SCHEMA2)
+      encoded = encode_datum(datum, REMOTE_SCHEMA2, config)
       d.instance.parse(encoded) do |_time, record|
         assert_equal datum.merge("verified" => false), record
       end
     end
 
-    def test_schema_registery_with_subject_url
+    data("use_confluent_schema" => true,
+         "plain"                => false)
+    def test_schema_registery_with_subject_url(data)
+      config = data
       conf = {
         'schema_registery_with_subject_url' => "http://localhost:8081/subjects/persons-avro-value/",
-        'schema_url_key' => 'schema'
+        'schema_url_key' => 'schema',
+        'use_confluent_schema' => config,
       }
       d = create_driver(conf)
       datum = {"firstName" => "Aleen","lastName" => "Terry","birthDate" => 159202477258}
-      encoded = encode_datum(datum, REMOTE_SCHEMA2)
+      encoded = encode_datum(datum, REMOTE_SCHEMA2, config)
       d.instance.parse(encoded) do |_time, record|
         assert_equal datum.merge("verified" => nil), record
       end
     end
 
-    def test_schema_registery_with_invalid_subject_url
+    def test_schema_registery_with_invalid_subject_url(data)
       conf = {
         'schema_registery_with_subject_url' => "http://localhost:8081/subjects/persons-avro-value",
         'schema_url_key' => 'schema'
@@ -372,9 +404,13 @@ class AvroParserTest < Test::Unit::TestCase
 
   private
 
-  def encode_datum(datum, string_schema)
+  def encode_datum(datum, string_schema, use_confluent_schema = true, schema_id = 1)
     buffer = StringIO.new
     encoder = Avro::IO::BinaryEncoder.new(buffer)
+    if use_confluent_schema
+      encoder.write(Fluent::Plugin::AvroParser::MAGIC_BYTE)
+      encoder.write([schema_id].pack("N"))
+    end
     schema = Avro::Schema.parse(string_schema)
     writer = Avro::IO::DatumWriter.new(schema)
     writer.write(datum, encoder)

--- a/test/plugin/test_parser_avro.rb
+++ b/test/plugin/test_parser_avro.rb
@@ -412,23 +412,6 @@ class AvroParserTest < Test::Unit::TestCase
       end
     end
 
-    data("use_confluent_schema" => true,
-         "plain"                => false)
-    def test_schema_registery_with_subject_url(data)
-      config = data
-      conf = {
-        'schema_registery_with_subject_url' => "http://localhost:8081/subjects/persons-avro-value/",
-        'schema_url_key' => 'schema',
-        'use_confluent_schema' => config,
-      }
-      d = create_driver(conf)
-      datum = {"firstName" => "Aleen","lastName" => "Terry","birthDate" => 159202477258}
-      encoded = encode_datum(datum, REMOTE_SCHEMA2, config)
-      d.instance.parse(encoded) do |_time, record|
-        assert_equal datum.merge("verified" => nil), record
-      end
-    end
-
     def test_confluent_registry_with_schema_version
       conf = Fluent::Config::Element.new(
         '', '', {'@type' => 'avro'}, [
@@ -463,16 +446,6 @@ class AvroParserTest < Test::Unit::TestCase
       encoded = encode_datum(datum, schema.fetch("schema"), true, 1)
       d.instance.parse(encoded) do |_time, record|
         assert_equal datum, record
-      end
-    end
-
-    def test_schema_registery_with_invalid_subject_url(data)
-      conf = {
-        'schema_registery_with_subject_url' => "http://localhost:8081/subjects/persons-avro-value",
-        'schema_url_key' => 'schema'
-      }
-      assert_raise(Fluent::ConfigError) do
-        create_driver(conf)
       end
     end
   end


### PR DESCRIPTION
When using confluent registry schema, the first 5-bytes should skip to read because they contain magic byte and schema_id and the latter bytes contain record contents.