### PR TITLE
Support with API_KEY and API_SECRET

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ $ bundle
 * **readers_schema_json** (string) (optional): avro schema definition hash for readers definition.
 * **use_confluent_schema** (bool) (optional): Assume to use confluent schema. Confluent avro schema uses the first 5-bytes for magic byte (1 byte) and schema_id (4 bytes). This parameter specifies to skip reading the first 5-bytes or not.
   * Default value: `true`.
+* **api_key** (string) (optional): Set key for Basic authentication.
+* **api_secret** (string) (optional): Set secret for Basic authentication.
 
 ### \<confluent_registry\> section (optional) (single)
 

--- a/lib/fluent/plugin/confluent_avro_schema_registry.rb
+++ b/lib/fluent/plugin/confluent_avro_schema_registry.rb
@@ -18,15 +18,19 @@ require "uri"
 
 module Fluent
   module Plugin
+    class ConfluentAvroSchemaRegistryUnauthorizedError < StandardError; end
+
     class ConfluentAvroSchemaRegistry
-      def initialize(registry_url)
+      def initialize(registry_url, api_key=nil, api_secret=nil)
         @registry_url = registry_url
+        @api_key = api_key
+        @api_secret = api_secret
       end
 
       def subject_version(subject, schema_key, version = "latest")
         registry_uri = URI.parse(@registry_url)
         registry_uri_with_versions = URI.join(registry_uri, "/subjects/#{subject}/versions/#{version}")
-        response = Net::HTTP.get_response(registry_uri_with_versions)
+        response = get_response(registry_uri_with_versions)
         if schema_key.nil?
           response.body
         else
@@ -37,12 +41,30 @@ module Fluent
       def schema_with_id(schema_id, schema_key)
         registry_uri = URI.parse(@registry_url)
         registry_uri_with_ids = URI.join(registry_uri, "/schemas/ids/#{schema_id}")
-        response = Net::HTTP.get_response(registry_uri_with_ids)
+        response = get_response(registry_uri_with_ids)
         if schema_key.nil?
           response.body
         else
           Yajl.load(response.body)[schema_key]
         end
+      end
+
+      def get_response(uri)
+        response = if @api_key and @api_secret
+                     Net::HTTP.start(uri.host, uri.port) do |http|
+                       request = Net::HTTP::Get.new(uri.path)
+                       request.basic_auth(@api_key, @api_secret)
+                       http.request(request)
+                     end
+                   else
+                     Net::HTTP.get_response(uri)
+                   end
+        if @api_key and @api_secret
+          if response.is_a?(Net::HTTPUnauthorized)
+            raise ConfluentAvroSchemaRegistryUnauthorizedError
+          end
+        end
+        response
       end
     end
   end


### PR DESCRIPTION
ref. https://docs.confluent.io/platform/current/schema-registry/develop/using.html#common-sr-api-usage-examples