### PR TITLE
Replace yajl-ruby with the json gem for JSON handling

### DIFF
--- a/lib/fluent/plugin/confluent_avro_schema_registry.rb
+++ b/lib/fluent/plugin/confluent_avro_schema_registry.rb
@@ -34,7 +34,7 @@ module Fluent
         if schema_key.nil?
           response.body
         else
-          Yajl.load(response.body)[schema_key]
+          JSON.parse(response.body)[schema_key]
         end
       end
 
@@ -45,7 +45,7 @@ module Fluent
         if schema_key.nil?
           response.body
         else
-          Yajl.load(response.body)[schema_key]
+          JSON.parse(response.body)[schema_key]
         end
       end
 

--- a/lib/fluent/plugin/parser_avro.rb
+++ b/lib/fluent/plugin/parser_avro.rb
@@ -174,7 +174,7 @@ module Fluent
         if schema_key.nil?
           response.body
         else
-          Yajl.load(response.body)[schema_key]
+          JSON.parse(response.body)[schema_key]
         end
       end
     end

--- a/test/plugin/test_parser_avro.rb
+++ b/test/plugin/test_parser_avro.rb
@@ -424,7 +424,7 @@ class AvroParserTest < Test::Unit::TestCase
         ])
       d = create_driver(conf)
       datum = {"firstName" => "Aleen","lastName" => "Terry","birthDate" => 159202477258}
-      schema = Yajl.load(File.read(File.join(__dir__, "..", "data", "schema-persions-value-1.avsc")))
+      schema = JSON.parse(File.read(File.join(__dir__, "..", "data", "schema-persions-value-1.avsc")))
       encoded = encode_datum(datum, schema.fetch("schema"), true, 1)
       d.instance.parse(encoded) do |_time, record|
         assert_equal datum, record
@@ -442,7 +442,7 @@ class AvroParserTest < Test::Unit::TestCase
         ])
       d = create_driver(conf)
       datum = {"firstName" => "Aleen","lastName" => "Terry","birthDate" => 159202477258}
-      schema = Yajl.load(File.read(File.join(__dir__, "..", "data", "schema-persions-value-1.avsc")))
+      schema = JSON.parse(File.read(File.join(__dir__, "..", "data", "schema-persions-value-1.avsc")))
       encoded = encode_datum(datum, schema.fetch("schema"), true, 1)
       d.instance.parse(encoded) do |_time, record|
         assert_equal datum, record
@@ -506,7 +506,7 @@ class AvroParserTest < Test::Unit::TestCase
                                       }, [])
         ])
       datum = {"firstName" => "Aleen","lastName" => "Terry","birthDate" => 159202477258}
-      schema = Yajl.load(File.read(File.join(__dir__, "..", "data", "schema-persions-value-1.avsc")))
+      schema = JSON.parse(File.read(File.join(__dir__, "..", "data", "schema-persions-value-1.avsc")))
       encoded = encode_datum(datum, schema.fetch("schema"), true, 1)
       d = create_driver(conf)
       d.instance.parse(encoded) do |_time, record|


### PR DESCRIPTION
Since the yajl-ruby gem depends on a deprecated Ruby C API, it cannot be installed with Ruby 4.1.