### PR TITLE
Allow duplicate keys in JSON parser

### DIFF
--- a/lib/fluent/plugin/confluent_avro_schema_registry.rb
+++ b/lib/fluent/plugin/confluent_avro_schema_registry.rb
@@ -34,7 +34,7 @@ module Fluent
         if schema_key.nil?
           response.body
         else
-          JSON.parse(response.body)[schema_key]
+          JSON.parse(response.body, allow_duplicate_key: true)[schema_key]
         end
       end
 
@@ -45,7 +45,7 @@ module Fluent
         if schema_key.nil?
           response.body
         else
-          JSON.parse(response.body)[schema_key]
+          JSON.parse(response.body, allow_duplicate_key: true)[schema_key]
         end
       end
 

--- a/lib/fluent/plugin/parser_avro.rb
+++ b/lib/fluent/plugin/parser_avro.rb
@@ -174,7 +174,7 @@ module Fluent
         if schema_key.nil?
           response.body
         else
-          JSON.parse(response.body)[schema_key]
+          JSON.parse(response.body, allow_duplicate_key: true)[schema_key]
         end
       end
     end


### PR DESCRIPTION
The json gem emits a deprecation warning for duplicate keys in JSON objects and will raise `JSON::ParserError` in json 3.0 unless `allow_duplicate_key: true` is specified.

The plugin has historically accepted duplicate keys silently (last value wins).
To preserve this behavior uniformly regardless of the json gem version, this passes `allow_duplicate_key: true` to `JSON.parse`.

Note that `allow_duplicate_key` is silently ignored by json < 2.13, so this is safe with older json gem versions.